### PR TITLE
add ISCO bounds

### DIFF
--- a/FOORT/src/Config.cpp
+++ b/FOORT/src/Config.cpp
@@ -606,7 +606,9 @@ void Config::InitializeDiagnostics(const ConfigCollection &theCfg, DiagBitflag &
 			real defaultxi{1.0};
 			real defaultbetar{1.0};
 			real defaultbetaphi{1.0};
-			std::unique_ptr<FluidVelocityModel> theFluidModel{new GeneralCircularRadialFluid(defaultxi, defaultbetar, defaultbetaphi, theMetric)};
+			real defaultiscolowerbound{0.0};
+			real defaultiscoupperbound{1000.0};
+			std::unique_ptr<FluidVelocityModel> theFluidModel{new GeneralCircularRadialFluid(defaultxi, defaultbetar, defaultbetaphi, theMetric, defaultiscolowerbound, defaultiscoupperbound)};
 
 			// Read in fluid velocity model
 			std::string fluidmodelstring{""};
@@ -616,11 +618,15 @@ void Config::InitializeDiagnostics(const ConfigCollection &theCfg, DiagBitflag &
 				real subKeplerianparam{defaultxi};
 				real betaR{defaultbetar};
 				real betaPhi{defaultbetaphi};
+				real iscolowerbound{defaultiscolowerbound};
+				real iscoupperbound{defaultiscoupperbound};
 				AllDiagSettings["EquatorialEmission"].LookupValue("xi", subKeplerianparam);
 				AllDiagSettings["EquatorialEmission"].LookupValue("betar", betaR);
 				AllDiagSettings["EquatorialEmission"].LookupValue("betaphi", betaPhi);
+				AllDiagSettings["EquatorialEmission"].LookupValue("ISCOLowerBound", iscolowerbound);
+				AllDiagSettings["EquatorialEmission"].LookupValue("ISCOUpperBound", iscoupperbound);
 
-				theFluidModel = std::unique_ptr<FluidVelocityModel>{new GeneralCircularRadialFluid(subKeplerianparam, betaR, betaPhi, theMetric)};
+				theFluidModel = std::unique_ptr<FluidVelocityModel>{new GeneralCircularRadialFluid(subKeplerianparam, betaR, betaPhi, theMetric, iscolowerbound, iscoupperbound)};
 			}
 			// Other fluid velocity models can be checked for here...
 

--- a/FOORT/src/DiagnosticsEmission.cpp
+++ b/FOORT/src/DiagnosticsEmission.cpp
@@ -180,7 +180,7 @@ std::string GeneralCircularRadialFluid::getFullDescriptionStr() const
 	if (m_ISCOexists && m_theMetric->getrLogScale())
 		trueISCOradius = exp(m_ISCOr);
 
-	return "Circular/radial flow (sub-Keplerian parameter xi = " + std::to_string(m_subKeplerParam) + ", beta_r = " + std::to_string(m_betaR) + ", beta_phi = " + std::to_string(m_betaPhi) + "; " + (m_ISCOexists ? "ISCO = " + std::to_string(trueISCOradius) : "no ISCO found") + ")";
+	return "Circular/radial flow (sub-Keplerian parameter xi = " + std::to_string(m_subKeplerParam) + ", beta_r = " + std::to_string(m_betaR) + ", beta_phi = " + std::to_string(m_betaPhi) + "; " + (m_ISCOexists ? "ISCO = " + std::to_string(trueISCOradius) : "no ISCO found") + "; " + "ISCO lower bound = " + std::to_string(m_ISCOlowerbound) + ", ISCO upper bound = " + std::to_string(m_ISCOupperbound) + ")";
 }
 
 /**
@@ -352,13 +352,19 @@ OneIndex GeneralCircularRadialFluid::GetRadialVelocityd(const Point &p) const
  */
 void GeneralCircularRadialFluid::FindISCO()
 {
-	real lowerbound{0.0};
-	real upperbound{1000.0};
+	real lowerbound{m_ISCOlowerbound};
+	real upperbound{m_ISCOupperbound};
 	const SphericalHorizonMetric *sphermetric = dynamic_cast<const SphericalHorizonMetric *>(m_theMetric);
 	if (sphermetric)
 	{
 		lowerbound = sphermetric->getrLogScale() ? log(sphermetric->getHorizonRadius()) : sphermetric->getHorizonRadius();
 		upperbound = sphermetric->getrLogScale() ? log(10.0 * sphermetric->getHorizonRadius()) : 10.0 * sphermetric->getHorizonRadius();
+	}
+	else if (m_theMetric->getrLogScale())
+	{
+		// If not a spherical horizon metric, but we are using log(r) coordinates, then set the lower bound to 0.0
+		lowerbound = log(m_ISCOlowerbound); // ln(0.05) = -3.912023005428146
+		upperbound = log(m_ISCOupperbound); // ln(1000.0) = 6.907755278982137
 	}
 
 	// Perform binary search for ISCO

--- a/FOORT/src/DiagnosticsEmission.h
+++ b/FOORT/src/DiagnosticsEmission.h
@@ -95,8 +95,10 @@ protected:
 struct GeneralCircularRadialFluid final : public FluidVelocityModel
 {
 	// Constructor with three parameters and Metric pointer (which is passed to base class constructor)
-	GeneralCircularRadialFluid(real subKeplerParam, real betar, real betaphi, const Metric *const theMetric) : m_subKeplerParam{fmin(fmax(subKeplerParam, 0.0), 1.0)}, m_betaR{fmin(fmax(betar, 0.0), 1.0)},
-																											   m_betaPhi{fmin(fmax(betaphi, 0.0), 1.0)}, FluidVelocityModel(theMetric)
+	GeneralCircularRadialFluid(real subKeplerParam, real betar, real betaphi, const Metric *const theMetric,
+							   real ISCO_lowerbound, real ISCO_upperbound) : m_subKeplerParam{fmin(fmax(subKeplerParam, 0.0), 1.0)}, m_betaR{fmin(fmax(betar, 0.0), 1.0)},
+																			 m_betaPhi{fmin(fmax(betaphi, 0.0), 1.0)}, FluidVelocityModel(theMetric),
+																			 m_ISCOlowerbound{ISCO_lowerbound}, m_ISCOupperbound{ISCO_upperbound}
 	{
 		// Do some checks on three params, which must lie between 0.0 and 1.0 (note that they are adjusted as such in
 		// initializer above)
@@ -150,6 +152,10 @@ private:
 	bool m_ISCOexists{false};
 	//! ISCO radius
 	real m_ISCOr{-1.0};
+	//! Lower bound for ISCO radius search
+	real m_ISCOlowerbound;
+	//! Upper bound for ISCO radius search
+	real m_ISCOupperbound;
 	//! ISCO t momentum
 	real m_ISCOpt{};
 	//! ISCO phi momentum

--- a/README.md
+++ b/README.md
@@ -36,15 +36,23 @@ Recent versions of MacOS may encounter issues with CMake. The following seems to
 (Found in [this issue](https://gist.github.com/scivision/d69faebbc56da9714798087b56de925a))
 
 ```
+export CC=/opt/homebrew/bin/gcc-14
 export CXX=/opt/homebrew/bin/g++-14
+export FC=/opt/homebrew/bin/gfortran-14
 export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/
 ```
 
-For convenience, this is stored in `alternative_builds/MacOS_workaround.sh`, which should be executed with `source \the\path\` in the terminal in case issues are encountered. You may need to `rm -rf build` in order to start clean.
+For convenience, this is stored in `alternative_builds/MacOS_workaround.sh`, which should be executed with `source \the\path\` in the terminal in case issues are encountered. You may need to `rm -rf build` in order to start clean. In case this doesn't work (which is not unlikely - some of it is black magic), one can also revert to the `makefile_mac` as described below.
 
 #### Old MakeFiles
 
-Alternatively, old Makefiles can be found in `alternative_builds/old_makefiles`. These can be system dependent, however, but should be adaptable to your needs.
+Alternatively, old Makefiles can be found in `alternative_builds/old_makefiles`. These can be system dependent, however, but should be adaptable to your needs. If the user wants to use these, the relevant makefile should be copied into the `src` folder, in which
+
+```
+make -f <makefile>
+```
+
+should be run, where `<makefile>` should be replaced with the name of the relevant file.
 
 ### WINDOWS VISUAL STUDIO
 


### PR DESCRIPTION
Added the option of setting bounds on the binary search for the ISCO radius, done in the GeneralCircularRadialFluid, manually. This is necessary for the Boson Star example. 

I also added the log rescaling for non-horizon metrics  that are using log scale.

Updated README for the part on the Mac compilation.